### PR TITLE
Fix script position in cat page

### DIFF
--- a/src/pages/cat.astro
+++ b/src/pages/cat.astro
@@ -11,5 +11,5 @@ import Layout from "../layouts/Layout.astro";
   <div id="cat" class="flex py-6 px-2 justify-center">
     <h3 id="loading">Loading</h3>
   </div>
+  <script type="module" src="../libs/replaceImage.ts"></script>
 </Layout>
-<script src="../libs/replaceImage.ts"></script>


### PR DESCRIPTION
## Summary
- ensure the client script for the cat page is included inside the `Layout` component

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686255247e408320956272c6beb8c0a0